### PR TITLE
Bold/Italic functionality

### DIFF
--- a/Groovy-Edit/src/GroovyEditGUI.form
+++ b/Groovy-Edit/src/GroovyEditGUI.form
@@ -157,7 +157,7 @@
       <SubComponents>
         <Component class="javax.swing.JButton" name="jButton1">
           <Properties>
-            <Property name="text" type="java.lang.String" value="jButton1"/>
+            <Property name="text" type="java.lang.String" value="Bold"/>
             <Property name="focusable" type="boolean" value="false"/>
             <Property name="horizontalTextPosition" type="int" value="0"/>
             <Property name="verticalTextPosition" type="int" value="3"/>
@@ -168,7 +168,7 @@
         </Component>
         <Component class="javax.swing.JButton" name="jButton2">
           <Properties>
-            <Property name="text" type="java.lang.String" value="jButton2"/>
+            <Property name="text" type="java.lang.String" value="Italic"/>
             <Property name="focusable" type="boolean" value="false"/>
             <Property name="horizontalTextPosition" type="int" value="0"/>
             <Property name="verticalTextPosition" type="int" value="3"/>

--- a/Groovy-Edit/src/GroovyEditGUI.java
+++ b/Groovy-Edit/src/GroovyEditGUI.java
@@ -20,6 +20,7 @@ public class GroovyEditGUI extends javax.swing.JFrame {
     /**
      * Creates new form GroovyEditGUI
      */
+    boldItalic b = new boldItalic();
     public GroovyEditGUI() {
         this.currentFilePath = ""; // Initializes the string
         this.currentFileExt = "";
@@ -66,7 +67,7 @@ public class GroovyEditGUI extends javax.swing.JFrame {
         jToolBar1.setMinimumSize(new java.awt.Dimension(440, 40));
         jToolBar1.setPreferredSize(new java.awt.Dimension(430, 40));
 
-        jButton1.setText("jButton1");
+        jButton1.setText("Bold");
         jButton1.setFocusable(false);
         jButton1.setHorizontalTextPosition(javax.swing.SwingConstants.CENTER);
         jButton1.setVerticalTextPosition(javax.swing.SwingConstants.BOTTOM);
@@ -77,7 +78,7 @@ public class GroovyEditGUI extends javax.swing.JFrame {
         });
         jToolBar1.add(jButton1);
 
-        jButton2.setText("jButton2");
+        jButton2.setText("Italic");
         jButton2.setFocusable(false);
         jButton2.setHorizontalTextPosition(javax.swing.SwingConstants.CENTER);
         jButton2.setVerticalTextPosition(javax.swing.SwingConstants.BOTTOM);
@@ -187,11 +188,11 @@ public class GroovyEditGUI extends javax.swing.JFrame {
     }// </editor-fold>//GEN-END:initComponents
 
     private void jButton1ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jButton1ActionPerformed
-        // TODO add your handling code here:
+        b.changeStyle(jTextPane1, 1);
     }//GEN-LAST:event_jButton1ActionPerformed
 
     private void jButton2ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jButton2ActionPerformed
-        // TODO add your handling code here:
+        b.changeStyle(jTextPane1, 0);
     }//GEN-LAST:event_jButton2ActionPerformed
 
     private void jButton3ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jButton3ActionPerformed

--- a/Groovy-Edit/src/boldItalic.java
+++ b/Groovy-Edit/src/boldItalic.java
@@ -1,0 +1,45 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.JTextPane;
+import javax.swing.text.AttributeSet;
+import javax.swing.text.Element;
+import javax.swing.text.MutableAttributeSet;
+import javax.swing.text.SimpleAttributeSet;
+import javax.swing.text.StyleConstants;
+import javax.swing.text.StyledDocument;
+
+/**
+ *
+ * @author Robert Brosig
+ */
+public class boldItalic {
+    public boolean changeStyle(JTextPane inp, int style){ //0 is italic, 1 is bold
+        StyledDocument d = (StyledDocument) inp.getStyledDocument();
+        int selSt = inp.getSelectionStart();
+        int selEn = inp.getSelectionEnd();
+        if (selSt == selEn){
+            return false;
+        }
+        Element ele = d.getCharacterElement(selSt);
+        AttributeSet as = ele.getAttributes();
+        
+        MutableAttributeSet asN = new SimpleAttributeSet(as.copyAttributes());
+        switch (style){
+            case 0: StyleConstants.setItalic(asN, !StyleConstants.isItalic(as));
+                    break;
+            case 1: StyleConstants.setBold(asN, !StyleConstants.isBold(as));
+                    break;
+            default:StyleConstants.setBold(asN, false);
+                    StyleConstants.setItalic(asN, false);
+        }
+        d.setCharacterAttributes(selSt, selEn-selSt, asN, true);
+        return true;
+        
+    }
+}


### PR DESCRIPTION
It seems to work fine for individual characters in the text pane, and changes the first two buttons into bold and italic, respectfully.  Unsure if the save functionality will keep the bold/italics, but we can fix that later.